### PR TITLE
Update relation ordering syntax in post.yml

### DIFF
--- a/types/post.yml
+++ b/types/post.yml
@@ -19,15 +19,15 @@ relations:
     authors:
         references: author
         type: many
-        orderBy:
-            - key: title
-              direction: asc
+        order:
+            key: title
+            direction: asc
     tags:
         references: tag
         type: many
-        orderBy:
-            - key: title
-              direction: asc
+        order:
+            key: title
+            direction: asc
 
 queries:
     prev:


### PR DESCRIPTION
Replaces 'orderBy' array with 'order' object for authors and tags relations to streamline configuration and improve consistency.